### PR TITLE
Description command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DescriptionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DescriptionCommand.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands;
+
+public class DescriptionCommand {
+}

--- a/src/main/java/seedu/address/logic/commands/DescriptionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DescriptionCommand.java
@@ -1,4 +1,31 @@
 package seedu.address.logic.commands;
 
-public class DescriptionCommand {
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Changes the description of an existing expense entry in finance log.
+ */
+public class DescriptionCommand extends Command {
+
+    public static final String COMMAND_WORD = "description";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits the description of expense entry identified "
+            + "by the index number used in the last expense entry listing. "
+            + "Existing remark will be overwritten by the input.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_DESCRIPTION + "[DESCRIPTION]\n"
+            + "Example: " + COMMAND_WORD + " 2 "
+            + PREFIX_DESCRIPTION + "Father's birthday present.";
+
+    public static final String EXCEPTION_MESSAGE = "Description command not yet implemented";
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        throw new CommandException(EXCEPTION_MESSAGE);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/DescriptionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DescriptionCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -22,10 +24,38 @@ public class DescriptionCommand extends Command {
             + "Example: " + COMMAND_WORD + " 2 "
             + PREFIX_DESCRIPTION + "Father's birthday present.";
 
-    public static final String EXCEPTION_MESSAGE = "Description command not yet implemented";
+    public static final String MESSAGE_ARGUMENTS = "Index: %1$d, Description: %2$s";
+
+    private final Index index;
+    private final String description;
+
+    /**
+     * @param index Index of the expense entry in the filtered expense list to edit description
+     * @param description description of the expense entry to be updated to
+     */
+    public DescriptionCommand(Index index, String description) {
+        requireAllNonNull(index, description);
+
+        this.index = index;
+        this.description = description;
+    }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
-        throw new CommandException(EXCEPTION_MESSAGE);
+        throw new CommandException(String.format(MESSAGE_ARGUMENTS, index.getOneBased(), description));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof DescriptionCommand)) {
+            return false;
+        }
+
+        DescriptionCommand e = (DescriptionCommand) other;
+        return index.equals(e.index) && description.equals(e.description);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -51,7 +51,7 @@ public class AddressBookParser {
 
         switch (commandWord) {
             case DescriptionCommand.COMMAND_WORD:
-                return new DescriptionCommand();
+                return new DescriptionCommandParser().parse(arguments);
 
             case SpendCommand.COMMAND_WORD:
             case SpendCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DescriptionCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -19,7 +20,6 @@ import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SpendCommand;
 import seedu.address.logic.commands.UndoCommand;
-import seedu.address.logic.commands.DescriptionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 
@@ -50,62 +50,62 @@ public class AddressBookParser {
         final String arguments = matcher.group("arguments");
 
         switch (commandWord) {
-            case DescriptionCommand.COMMAND_WORD:
-                return new DescriptionCommandParser().parse(arguments);
+        case DescriptionCommand.COMMAND_WORD:
+            return new DescriptionCommandParser().parse(arguments);
 
-            case SpendCommand.COMMAND_WORD:
-            case SpendCommand.COMMAND_ALIAS:
-                return new SpendCommandParser().parse(arguments);
+        case SpendCommand.COMMAND_WORD:
+        case SpendCommand.COMMAND_ALIAS:
+            return new SpendCommandParser().parse(arguments);
 
-            case EditCommand.COMMAND_WORD:
-            case EditCommand.COMMAND_ALIAS:
-                return new EditCommandParser().parse(arguments);
+        case EditCommand.COMMAND_WORD:
+        case EditCommand.COMMAND_ALIAS:
+            return new EditCommandParser().parse(arguments);
 
-            case SelectCommand.COMMAND_WORD:
-            case SelectCommand.COMMAND_ALIAS:
-            case SelectCommand.COMMAND_ALIAS2:
-                return new SelectCommandParser().parse(arguments);
+        case SelectCommand.COMMAND_WORD:
+        case SelectCommand.COMMAND_ALIAS:
+        case SelectCommand.COMMAND_ALIAS2:
+            return new SelectCommandParser().parse(arguments);
 
-            case DeleteCommand.COMMAND_WORD:
-            case DeleteCommand.COMMAND_ALIAS:
-            case DeleteCommand.COMMAND_ALIAS2:
-                return new DeleteCommandParser().parse(arguments);
+        case DeleteCommand.COMMAND_WORD:
+        case DeleteCommand.COMMAND_ALIAS:
+        case DeleteCommand.COMMAND_ALIAS2:
+            return new DeleteCommandParser().parse(arguments);
 
-            case ClearCommand.COMMAND_WORD:
-            case ClearCommand.COMMAND_ALIAS:
-            case ClearCommand.COMMAND_ALIAS2:
-                return new ClearCommand();
+        case ClearCommand.COMMAND_WORD:
+        case ClearCommand.COMMAND_ALIAS:
+        case ClearCommand.COMMAND_ALIAS2:
+            return new ClearCommand();
 
-            case SearchCommand.COMMAND_WORD:
-            case SearchCommand.COMMAND_ALIAS:
-                return new SearchCommandParser().parse(arguments);
+        case SearchCommand.COMMAND_WORD:
+        case SearchCommand.COMMAND_ALIAS:
+            return new SearchCommandParser().parse(arguments);
 
-            case ListCommand.COMMAND_WORD:
-            case ListCommand.COMMAND_ALIAS:
-            case ListCommand.COMMAND_ALIAS2:
-                return new ListCommand();
+        case ListCommand.COMMAND_WORD:
+        case ListCommand.COMMAND_ALIAS:
+        case ListCommand.COMMAND_ALIAS2:
+            return new ListCommand();
 
-            case HistoryCommand.COMMAND_WORD:
-            case HistoryCommand.COMMAND_ALIAS:
-            case HistoryCommand.COMMAND_ALIAS2:
-                return new HistoryCommand();
+        case HistoryCommand.COMMAND_WORD:
+        case HistoryCommand.COMMAND_ALIAS:
+        case HistoryCommand.COMMAND_ALIAS2:
+            return new HistoryCommand();
 
-            case ExitCommand.COMMAND_WORD:
-                return new ExitCommand();
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
 
-            case HelpCommand.COMMAND_WORD:
-                return new HelpCommand();
+        case HelpCommand.COMMAND_WORD:
+            return new HelpCommand();
 
-            case UndoCommand.COMMAND_WORD:
-            case UndoCommand.COMMAND_ALIAS:
-                return new UndoCommand();
+        case UndoCommand.COMMAND_WORD:
+        case UndoCommand.COMMAND_ALIAS:
+            return new UndoCommand();
 
-            case RedoCommand.COMMAND_WORD:
-            case RedoCommand.COMMAND_ALIAS:
-                return new RedoCommand();
+        case RedoCommand.COMMAND_WORD:
+        case RedoCommand.COMMAND_ALIAS:
+            return new RedoCommand();
 
-            default:
-                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,7 +19,9 @@ import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SpendCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.DescriptionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+
 
 /**
  * Parses user input.
@@ -48,59 +50,62 @@ public class AddressBookParser {
         final String arguments = matcher.group("arguments");
 
         switch (commandWord) {
-        case SpendCommand.COMMAND_WORD:
-        case SpendCommand.COMMAND_ALIAS:
-            return new SpendCommandParser().parse(arguments);
+            case DescriptionCommand.COMMAND_WORD:
+                return new DescriptionCommand();
 
-        case EditCommand.COMMAND_WORD:
-        case EditCommand.COMMAND_ALIAS:
-            return new EditCommandParser().parse(arguments);
+            case SpendCommand.COMMAND_WORD:
+            case SpendCommand.COMMAND_ALIAS:
+                return new SpendCommandParser().parse(arguments);
 
-        case SelectCommand.COMMAND_WORD:
-        case SelectCommand.COMMAND_ALIAS:
-        case SelectCommand.COMMAND_ALIAS2:
-            return new SelectCommandParser().parse(arguments);
+            case EditCommand.COMMAND_WORD:
+            case EditCommand.COMMAND_ALIAS:
+                return new EditCommandParser().parse(arguments);
 
-        case DeleteCommand.COMMAND_WORD:
-        case DeleteCommand.COMMAND_ALIAS:
-        case DeleteCommand.COMMAND_ALIAS2:
-            return new DeleteCommandParser().parse(arguments);
+            case SelectCommand.COMMAND_WORD:
+            case SelectCommand.COMMAND_ALIAS:
+            case SelectCommand.COMMAND_ALIAS2:
+                return new SelectCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-        case ClearCommand.COMMAND_ALIAS:
-        case ClearCommand.COMMAND_ALIAS2:
-            return new ClearCommand();
+            case DeleteCommand.COMMAND_WORD:
+            case DeleteCommand.COMMAND_ALIAS:
+            case DeleteCommand.COMMAND_ALIAS2:
+                return new DeleteCommandParser().parse(arguments);
 
-        case SearchCommand.COMMAND_WORD:
-        case SearchCommand.COMMAND_ALIAS:
-            return new SearchCommandParser().parse(arguments);
+            case ClearCommand.COMMAND_WORD:
+            case ClearCommand.COMMAND_ALIAS:
+            case ClearCommand.COMMAND_ALIAS2:
+                return new ClearCommand();
 
-        case ListCommand.COMMAND_WORD:
-        case ListCommand.COMMAND_ALIAS:
-        case ListCommand.COMMAND_ALIAS2:
-            return new ListCommand();
+            case SearchCommand.COMMAND_WORD:
+            case SearchCommand.COMMAND_ALIAS:
+                return new SearchCommandParser().parse(arguments);
 
-        case HistoryCommand.COMMAND_WORD:
-        case HistoryCommand.COMMAND_ALIAS:
-        case HistoryCommand.COMMAND_ALIAS2:
-            return new HistoryCommand();
+            case ListCommand.COMMAND_WORD:
+            case ListCommand.COMMAND_ALIAS:
+            case ListCommand.COMMAND_ALIAS2:
+                return new ListCommand();
 
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
+            case HistoryCommand.COMMAND_WORD:
+            case HistoryCommand.COMMAND_ALIAS:
+            case HistoryCommand.COMMAND_ALIAS2:
+                return new HistoryCommand();
 
-        case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            case ExitCommand.COMMAND_WORD:
+                return new ExitCommand();
 
-        case UndoCommand.COMMAND_WORD:
-        case UndoCommand.COMMAND_ALIAS:
-            return new UndoCommand();
+            case HelpCommand.COMMAND_WORD:
+                return new HelpCommand();
 
-        case RedoCommand.COMMAND_WORD:
-        case RedoCommand.COMMAND_ALIAS:
-            return new RedoCommand();
+            case UndoCommand.COMMAND_WORD:
+            case UndoCommand.COMMAND_ALIAS:
+                return new UndoCommand();
 
-        default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            case RedoCommand.COMMAND_WORD:
+            case RedoCommand.COMMAND_ALIAS:
+                return new RedoCommand();
+
+            default:
+                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-
+    public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
 }

--- a/src/main/java/seedu/address/logic/parser/DescriptionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DescriptionCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DescriptionCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parse input arguments and creates a new {@code DescriptionCommand} object.
+ */
+public class DescriptionCommandParser implements Parser<DescriptionCommand> {
+    public DescriptionCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DescriptionCommand.MESSAGE_USAGE, ive));
+        }
+
+        String description = argMultimap.getValue(PREFIX_DESCRIPTION).orElse("");
+
+        return new DescriptionCommand(index, description);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/DescriptionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DescriptionCommandParser.java
@@ -4,8 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.DescriptionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -13,6 +13,13 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parse input arguments and creates a new {@code DescriptionCommand} object.
  */
 public class DescriptionCommandParser implements Parser<DescriptionCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of {@code DescriptionCommand}
+     * and returns a {@code DescriptionCommand} object for execution.
+     * @param args User String input
+     * @return {@code DescriptionCommand} object for execution.
+     * @throws ParseException if user input does not follow expected format
+     */
     public DescriptionCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -36,6 +36,8 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_DESCRIPTION_AMY = "Birthday present for Amy";
+    public static final String VALID_DESCRIPTION_BOB = "Birthday present for Bob";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/commands/DescriptionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DescriptionCommandTest.java
@@ -13,8 +13,8 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.model.ModelManager;
 import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
 /**

--- a/src/test/java/seedu/address/logic/commands/DescriptionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DescriptionCommandTest.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.DescriptionCommand.EXCEPTION_MESSAGE;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.ModelManager;
+import seedu.address.model.Model;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with Model)and unit tests for DescriptionCommand.
+ */
+public class DescriptionCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute() {
+        assertCommandFailure(new DescriptionCommand(), model, new CommandHistory(), EXCEPTION_MESSAGE);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DescriptionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DescriptionCommandTest.java
@@ -1,7 +1,13 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.DescriptionCommand.EXCEPTION_MESSAGE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.DescriptionCommand.MESSAGE_ARGUMENTS;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Test;
@@ -20,6 +26,33 @@ public class DescriptionCommandTest {
 
     @Test
     public void execute() {
-        assertCommandFailure(new DescriptionCommand(), model, new CommandHistory(), EXCEPTION_MESSAGE);
+        final String description = "Some description";
+
+        assertCommandFailure(new DescriptionCommand(INDEX_FIRST_PERSON, description), model, new CommandHistory(),
+                String.format(MESSAGE_ARGUMENTS, INDEX_FIRST_PERSON.getOneBased(), description));
+    }
+
+    @Test
+    public void equals() {
+        final DescriptionCommand standardCommand = new DescriptionCommand(INDEX_FIRST_PERSON, VALID_DESCRIPTION_AMY);
+
+        // Object with same values -> returns true
+        DescriptionCommand commandWithSameValues = new DescriptionCommand(INDEX_FIRST_PERSON, VALID_DESCRIPTION_AMY);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // Same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> return false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new DescriptionCommand(INDEX_SECOND_PERSON, VALID_DESCRIPTION_AMY)));
+
+        // different description -> returns false
+        assertFalse(standardCommand.equals(new DescriptionCommand(INDEX_FIRST_PERSON, VALID_DESCRIPTION_BOB)));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -27,6 +27,7 @@ import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SpendCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.DescriptionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -91,6 +92,11 @@ public class AddressBookParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_ALIAS2 + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_description() throws Exception {
+        assertTrue(parser.parseCommand(DescriptionCommand.COMMAND_WORD) instanceof DescriptionCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
@@ -96,7 +97,10 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_description() throws Exception {
-        assertTrue(parser.parseCommand(DescriptionCommand.COMMAND_WORD) instanceof DescriptionCommand);
+        final String description = "Some description.";
+        DescriptionCommand command = (DescriptionCommand) parser.parseCommand(DescriptionCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_DESCRIPTION + description);
+        assertEquals(new DescriptionCommand(INDEX_FIRST_PERSON, description), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -17,6 +17,7 @@ import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DescriptionCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -28,7 +29,6 @@ import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SpendCommand;
 import seedu.address.logic.commands.UndoCommand;
-import seedu.address.logic.commands.DescriptionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;

--- a/src/test/java/seedu/address/logic/parser/DescriptionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DescriptionCommandParserTest.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DescriptionCommand;
+
+public class DescriptionCommandParserTest {
+    private DescriptionCommandParser parser = new DescriptionCommandParser();
+    private final String nonEmptyDescription = "Some description.";
+
+    @Test
+    public void parse_indexSpecified_success() {
+        // with remark
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_DESCRIPTION + nonEmptyDescription;
+        DescriptionCommand expectedCommand = new DescriptionCommand(INDEX_FIRST_PERSON, nonEmptyDescription);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // with no remark
+        userInput = targetIndex.getOneBased() + " " + PREFIX_DESCRIPTION;
+        expectedCommand = new DescriptionCommand(INDEX_FIRST_PERSON, "");
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingCompulsoryField_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DescriptionCommand.MESSAGE_USAGE);
+
+        // no index
+        assertParseFailure(parser, DescriptionCommand.COMMAND_WORD + " " + nonEmptyDescription, expectedMessage);
+
+        // no parameters
+        assertParseFailure(parser, DescriptionCommand.COMMAND_WORD, expectedMessage);
+    }
+}


### PR DESCRIPTION
- Modify DescriptionCommand to take in an Index and String for description, and print the two parameters as error message
- Modify DescriptionCommandTest to test the equals method
- Add DescriptionCommandParser that will know how to parse two arguments, one
index and one with prefix 'd/'
- Add DescriptionCommandParserTest that will test different boundary values for DescriptionCommandParser.
- Modify AddressBookParser to use the newly implemented DescriptionCommandParser
- Modify AddressBookParserTest to ensure that what the user input generated the correct command.